### PR TITLE
Removing code that plays the video automatically

### DIFF
--- a/src/jquery.youtubebackground.js
+++ b/src/jquery.youtubebackground.js
@@ -267,7 +267,6 @@ if (typeof Object.create !== "function") {
       if (this.options.mute) {
         e.target.mute();
       }
-      e.target.playVideo();
     },
 
     /**


### PR DESCRIPTION
Removing one line of code that plays the video automatically instead of letting the YouTube API determine if the video should autoplay or not based on the playerVars value for autoplay that is passed in. Fix for issue #40.